### PR TITLE
Add Tkinter GUI to filter scraped stock codes by closing price

### DIFF
--- a/stock_code_scrayping.py
+++ b/stock_code_scrayping.py
@@ -2,6 +2,13 @@ import requests
 from bs4 import BeautifulSoup
 import re
 import random
+import threading
+from typing import List, Optional, Tuple
+
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+import yfinance as yf
 
 def scrape_stock_codes(url):
     """
@@ -57,50 +64,186 @@ def filter_valid_codes(codes):
 
 
 
-def main():
-    url = "https://nikkeiyosoku.com/stock/all/"
-    print("サイトから銘柄コードを取得中...")
-    
-    try:
-        codes = scrape_stock_codes(url)
-    except Exception as e:
-        print("スクレイピング中にエラー:", e)
-        return
-    
-    if not codes:
-        print("銘柄コードが取得できませんでした。")
-        return
+def fetch_latest_close(code: str) -> Optional[float]:
+    """yfinanceを利用して指定銘柄の直近終値を取得する。"""
+    if not code or not code.isdigit():
+        return None
 
-    print("サイトから取得した銘柄数:", len(codes))
-    
-    # 有効なコードとして、1301以上の数値のみを対象にする
-    valid_codes = filter_valid_codes(codes)
-    print("有効な銘柄数（1301以上、REIT除外）:", len(valid_codes))
-    
+    ticker = f"{code}.T"
     try:
-        count = int(input("抽出したい銘柄数を入力してください: "))
-    except ValueError:
-        print("数値を入力してください。")
-        return
-    
-    if count > len(valid_codes):
-        print("指定された抽出件数が、有効な銘柄数（{}）を超えています。".format(len(valid_codes)))
-        return
+        history = yf.Ticker(ticker).history(period="5d", auto_adjust=False, prepost=False)
+        if history.empty:
+            history = yf.download(ticker, period="5d", progress=False)
+        if history.empty:
+            return None
 
-    # 完全ランダム抽出（重複なし）
-    chosen_codes = random.sample(valid_codes, count)
-    
-    # 例えば、銘柄コードを4桁で表示する場合はゼロパディング（英字がある場合は除く）
-    chosen_codes_formatted = []
-    for code in chosen_codes:
-        if code.isdigit():
-            chosen_codes_formatted.append(code.zfill(4))
+        closes = history["Close"].dropna()
+        if closes.empty:
+            return None
+        return float(closes.iloc[-1])
+    except Exception:
+        return None
+
+
+def select_codes_by_price(
+    codes: List[str], count: int, min_price: float, max_price: float
+) -> List[Tuple[str, float]]:
+    """価格条件を満たす銘柄コードを抽出する。"""
+
+    filtered: List[Tuple[str, float]] = []
+    shuffled_codes = codes[:]
+    random.shuffle(shuffled_codes)
+
+    for code in shuffled_codes:
+        if len(filtered) >= count:
+            break
+
+        close_price = fetch_latest_close(code)
+        if close_price is None:
+            continue
+
+        if min_price <= close_price <= max_price:
+            display_code = code.zfill(4) if code.isdigit() else code
+            filtered.append((display_code, close_price))
+
+    return filtered
+
+
+class StockScraperApp:
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        self.master.title("銘柄コードスクレイパー")
+
+        self.count_var = tk.StringVar(value="30")
+        self.min_price_var = tk.StringVar(value="100")
+        self.max_price_var = tk.StringVar(value="500")
+
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        padding = {"padx": 10, "pady": 5}
+
+        frame = ttk.Frame(self.master)
+        frame.grid(row=0, column=0, sticky="nsew")
+
+        self.master.columnconfigure(0, weight=1)
+        self.master.rowconfigure(1, weight=1)
+
+        ttk.Label(frame, text="抽出銘柄数").grid(row=0, column=0, sticky="w", **padding)
+        ttk.Entry(frame, textvariable=self.count_var, width=10).grid(
+            row=0, column=1, sticky="ew", **padding
+        )
+
+        ttk.Label(frame, text="終値下限 (円)").grid(row=1, column=0, sticky="w", **padding)
+        ttk.Entry(frame, textvariable=self.min_price_var, width=10).grid(
+            row=1, column=1, sticky="ew", **padding
+        )
+
+        ttk.Label(frame, text="終値上限 (円)").grid(row=2, column=0, sticky="w", **padding)
+        ttk.Entry(frame, textvariable=self.max_price_var, width=10).grid(
+            row=2, column=1, sticky="ew", **padding
+        )
+
+        self.start_button = ttk.Button(frame, text="スクレイピング開始", command=self.start_scraping)
+        self.start_button.grid(row=3, column=0, columnspan=2, pady=(10, 5))
+
+        self.status_var = tk.StringVar(value="準備完了")
+        ttk.Label(frame, textvariable=self.status_var).grid(row=4, column=0, columnspan=2, **padding)
+
+        columns = ("code", "price")
+        self.tree = ttk.Treeview(self.master, columns=columns, show="headings", height=15)
+        self.tree.heading("code", text="銘柄コード")
+        self.tree.heading("price", text="終値 (円)")
+        self.tree.column("code", width=120, anchor="center")
+        self.tree.column("price", width=120, anchor="e")
+        self.tree.grid(row=1, column=0, sticky="nsew", padx=10, pady=(0, 10))
+
+        scrollbar = ttk.Scrollbar(self.master, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=scrollbar.set)
+        scrollbar.grid(row=1, column=1, sticky="ns", pady=(0, 10))
+
+        self.master.grid_columnconfigure(0, weight=1)
+        self.master.grid_rowconfigure(1, weight=1)
+
+    def start_scraping(self) -> None:
+        try:
+            count = int(self.count_var.get())
+            if count <= 0:
+                raise ValueError
+        except ValueError:
+            messagebox.showerror("入力エラー", "抽出銘柄数は正の整数を入力してください。")
+            return
+
+        try:
+            min_price = float(self.min_price_var.get())
+            max_price = float(self.max_price_var.get())
+        except ValueError:
+            messagebox.showerror("入力エラー", "終値の範囲には数値を入力してください。")
+            return
+
+        if min_price > max_price:
+            messagebox.showerror("入力エラー", "終値の下限は上限以下である必要があります。")
+            return
+
+        self.status_var.set("スクレイピング中...")
+        self.start_button.config(state=tk.DISABLED)
+
+        threading.Thread(
+            target=self._scrape_in_thread,
+            args=(count, min_price, max_price),
+            daemon=True,
+        ).start()
+
+    def _scrape_in_thread(self, count: int, min_price: float, max_price: float) -> None:
+        url = "https://nikkeiyosoku.com/stock/all/"
+
+        try:
+            codes = scrape_stock_codes(url)
+            valid_codes = filter_valid_codes(codes)
+        except Exception as exc:
+            self.master.after(0, self._handle_error, f"スクレイピングに失敗しました: {exc}")
+            return
+
+        if not valid_codes:
+            self.master.after(0, self._handle_error, "有効な銘柄コードが見つかりませんでした。")
+            return
+
+        results = select_codes_by_price(valid_codes, count, min_price, max_price)
+
+        self.master.after(0, self._update_results, results, count, len(valid_codes))
+
+    def _handle_error(self, message: str) -> None:
+        self.status_var.set("エラーが発生しました")
+        self.start_button.config(state=tk.NORMAL)
+        messagebox.showerror("エラー", message)
+
+    def _update_results(
+        self, results: List[Tuple[str, float]], requested_count: int, total_valid: int
+    ) -> None:
+        self.tree.delete(*self.tree.get_children())
+
+        for code, price in results:
+            self.tree.insert("", tk.END, values=(code, f"{price:.2f}"))
+
+        if results:
+            status_message = f"{len(results)} 件の銘柄を表示中 (有効銘柄: {total_valid} 件)"
         else:
-            chosen_codes_formatted.append(code)
-    
-    print("\n抽出された銘柄コード一覧:")
-    for code in chosen_codes_formatted:
-        print(code)
+            status_message = "条件に一致する銘柄が見つかりませんでした。"
 
-if __name__ == '__main__':
+        self.status_var.set(status_message)
+        self.start_button.config(state=tk.NORMAL)
+
+        if len(results) < requested_count:
+            messagebox.showinfo(
+                "結果", f"条件に一致した銘柄は {len(results)} 件でした。"
+            )
+
+
+def main() -> None:
+    root = tk.Tk()
+    StockScraperApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the CLI workflow with a Tkinter-based interface for selecting the number of stocks to scrape and the acceptable price range
- integrate yfinance so the scraper filters out codes whose latest closing prices fall outside the user-specified bounds
- add background threading, status updates, and a tabular view for the filtered results

## Testing
- python -m compileall stock_code_scrayping.py

------
https://chatgpt.com/codex/tasks/task_e_68d642ea280083238cffceed9515c080